### PR TITLE
Collapse yarn.lock in diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+yarn.lock linguist-generated


### PR DESCRIPTION
See https://thoughtbot.com/blog/github-diff-supression and
https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github